### PR TITLE
Randomizing the map seed before restart

### DIFF
--- a/Ategon-QuickRestartMod/extensions/LevelStage.gd
+++ b/Ategon-QuickRestartMod/extensions/LevelStage.gd
@@ -7,5 +7,5 @@ func _input(ev):
 		Audio.sound("gui_loadout_startrun")
 		var startData = LevelStartData.new()
 		startData.loadout = GameWorld.loadoutStageConfig.duplicate()
-		
+		Level.randomizeSeed()
 		StageManager.startStage("stages/landing/landing", [startData])


### PR DESCRIPTION
I read on the Discord that the mod uses the same seed on restart. This change will randomize the seed upon restart!